### PR TITLE
Update version to 2.0.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.1.0",
+  "version": "2.0.1",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -150,7 +150,7 @@ function App() {
           )}
         </main>
         <footer className="App-footer">
-          <p>Developed by Mustafa Evleksiz</p>
+          <p>Developed by Mustafa Evleksiz - Version {defaultConfig.VERSION}</p>
         </footer>
       </div>
     </div>

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -7,5 +7,6 @@ export const config = {
   TOTAL_BATCHES: 2,
   SECONDS_PER_BATCH: 30,
   FRAME_INTERVAL_SECONDS: 3,
-  SOCKET: "https://videoii-server.onrender.com"
+  SOCKET: "https://videoii-server.onrender.com",
+  VERSION: "2.0.1"
 };

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "index.js",
 "scripts": {


### PR DESCRIPTION
## Summary
- bump client and server packages to `2.0.1`
- expose version via client config
- display version in client footer

## Testing
- `npm install` *(fails: missing dependencies earlier? oh we installed successfully)*
- `npm test --silent -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68794904945c8327b14997af2c25f0f6