### PR TITLE
Adjust mobile layout and analysis flow

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -6,7 +6,7 @@ body { font-family: 'Inter', sans-serif; background-color: var(--background-colo
 .App-header { text-align: center; margin-bottom: 40px; }
 .App-header h1 { font-size: 3rem; font-weight: 700; margin: 0; color: var(--primary-color); user-select: none; }
 .App-header p { font-size: 1.1rem; color: var(--subtle-text-color); }
-.controls-card, .status-card { background: var(--card-background); border-radius: 12px; padding: 30px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 30px; }
+.controls-card, .status-card { background: var(--card-background); border-radius: 12px; padding: 30px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 30px; animation: fadeIn 0.5s ease; }
 h2 { font-size: 1.5rem; border-bottom: 1px solid var(--border-color); padding-bottom: 15px; margin-top: 0; margin-bottom: 25px; display: flex; align-items: center; cursor: pointer; }
 .step-number { background-color: var(--primary-color); color: white; border-radius: 50%; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; font-size: 1rem; font-weight: 700; margin-right: 15px; flex-shrink: 0; }
 .form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 20px; margin-bottom: 30px; align-items: end; }
@@ -42,6 +42,7 @@ input[type="file"] { display: none; }
   padding: 10px;
   margin-top: 10px;
   font-size: 0.9rem;
+  animation: fadeIn 0.3s ease;
 }
 .App-footer { margin-top: 50px; padding-top: 20px; border-top: 1px solid var(--border-color); text-align: center; }
 .App-footer p { color: var(--subtle-text-color); font-size: 0.9rem; }
@@ -49,9 +50,15 @@ input[type="file"] { display: none; }
 .model-group { }
 
 @media (max-width: 480px) {
-  .model-group { display: flex; align-items: center; gap: 10px; }
+  .model-group {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    width: 100%;
+  }
   .model-group label { margin-bottom: 0; white-space: nowrap; }
-  .form-grid { grid-template-columns: 1fr 1fr; }
+  .form-grid { grid-template-columns: 1fr; }
 }
 
 body.dark-mode {
@@ -77,5 +84,16 @@ body.dark-mode {
   background: var(--primary-color);
   color: #fff;
   font-size: 0.8rem;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -102,6 +102,7 @@ function App() {
   const handleUpload = async () => {
     if (!selectedFile || !socketId) { setAnalysisStatus({ ...analysisStatus, error: 'Please select a file and wait for server connection.' }); return; }
     setIsLoading(true);
+    setOpenSection('analysis');
     setAnalysisStatus({ message: 'Uploading video...', percent: 0, result: '', error: '' });
     const durationNeeded = totalBatches * secondsPerBatch;
     let uploadFile = selectedFile;
@@ -228,17 +229,6 @@ function App() {
                   <div className="form-group"><label htmlFor="analysis-type">Analysis Type</label><select id="analysis-type" value={analysisType} onChange={(e) => setAnalysisType(e.target.value)} disabled={isLoading}><option value="general">General Analysis</option><option value="meeting">Meeting Analysis</option></select></div>
                   <div className="form-group"><label htmlFor="output-language">Report Language</label><select id="output-language" value={outputLanguage} onChange={(e) => setOutputLanguage(e.target.value)} disabled={isLoading}><option value="Turkish">Turkish</option><option value="English">English</option></select></div>
                 </div>
-                <button className="info-button" onClick={toggleConfigInfo}>📊</button>
-                {showConfigInfo && (
-                  <div className="tooltip">
-                    <p>Model: {selectedModel}</p>
-                    <p>Batches: {totalBatches}</p>
-                    <p>Seconds/Batch: {secondsPerBatch}</p>
-                    <p>Frame Interval: {frameInterval}</p>
-                    <p>Type: {analysisType}</p>
-                    <p>Language: {outputLanguage}</p>
-                  </div>
-                )}
               </>
             )}
           </div>
@@ -255,11 +245,22 @@ function App() {
                   </div>
                 )}
                 <button className="info-button" onClick={toggleFileInfo}>ℹ️</button>
+                <button className="info-button" onClick={toggleConfigInfo}>📊</button>
                 {showFileInfo && selectedFile && (
                   <div className="tooltip">
                     <p>Name: {selectedFile.name}</p>
                     <p>Size: {(selectedFile.size / (1024*1024)).toFixed(2)} MB</p>
                     {videoRef.current && <p>Duration: {Math.round(videoRef.current.duration)} s</p>}
+                  </div>
+                )}
+                {showConfigInfo && (
+                  <div className="tooltip">
+                    <p>Model: {selectedModel}</p>
+                    <p>Batches: {totalBatches}</p>
+                    <p>Seconds/Batch: {secondsPerBatch}</p>
+                    <p>Frame Interval: {frameInterval}</p>
+                    <p>Type: {analysisType}</p>
+                    <p>Language: {outputLanguage}</p>
                   </div>
                 )}
                 <button className="analyze-button" onClick={handleUpload} disabled={isLoading || !selectedFile}>{isLoading ? <Spinner /> : null}{isLoading ? 'Analyzing...' : 'Start Analysis'}</button>
@@ -269,7 +270,7 @@ function App() {
 
           {(isLoading || analysisStatus.result || analysisStatus.error) && (
             <div className="status-card">
-              <h2 onClick={() => toggleSection('analysis')}><span className="step-number">3</span> Analysis Progress</h2>
+              <h2 onClick={() => toggleSection('analysis')}><span className="step-number">3</span> Analysis</h2>
               {openSection === 'analysis' && (
                 <>
                   <div className="progress-bar-container"><div className="progress-bar" style={{ width: `${analysisStatus.percent}%` }}></div></div>

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -37,5 +37,5 @@ export const DEFAULT_MODEL = "speedy";
 export const config = {
   MODEL_NAME: "gemini-2.5-flash",
   SOCKET: "https://videoii-server.onrender.com",
-  VERSION: "2.2.0",
+  VERSION: "2.3.0",
 };

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "",
   "main": "index.js",
 "scripts": {


### PR DESCRIPTION
## Summary
- improve fade-in animation for cards and tooltips
- make model selection full width on small screens
- move configuration details button to upload section
- open analysis accordion automatically when processing starts
- bump package versions to 2.3.0

## Testing
- `npm test --silent` in `client` (no tests)
- `npm test` in `server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68795d8b33608327abc024be46ebc4fa