### PR TITLE
Enhance UI accordions and limit server memory

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -6,7 +6,9 @@ body { font-family: 'Inter', sans-serif; background-color: var(--background-colo
 .App-header { text-align: center; margin-bottom: 40px; }
 .App-header h1 { font-size: 3rem; font-weight: 700; margin: 0; color: var(--primary-color); user-select: none; }
 .App-header p { font-size: 1.1rem; color: var(--subtle-text-color); }
-.controls-card, .status-card { background: var(--card-background); border-radius: 12px; padding: 30px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 30px; animation: fadeIn 0.5s ease; }
+.controls-card, .status-card { background: var(--card-background); border-radius: 12px; padding: 30px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 30px; animation: fadeIn 0.5s ease; transition: max-height 0.4s ease, padding 0.3s ease; overflow: hidden; }
+.controls-card.closed, .status-card.closed { max-height: 60px; padding: 15px 30px; opacity: 0.8; }
+.controls-card.open, .status-card.open { max-height: 2000px; border: 2px solid var(--primary-color); background-color: rgba(0,122,255,0.05); }
 h2 { font-size: 1.5rem; border-bottom: 1px solid var(--border-color); padding-bottom: 15px; margin-top: 0; margin-bottom: 25px; display: flex; align-items: center; cursor: pointer; }
 .step-number { background-color: var(--primary-color); color: white; border-radius: 50%; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; font-size: 1rem; font-weight: 700; margin-right: 15px; flex-shrink: 0; }
 .form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 20px; margin-bottom: 30px; align-items: end; }
@@ -71,6 +73,10 @@ body.dark-mode {
   --border-color: #444;
   --success-color: #32d74b;
   --error-color: #ff453a;
+}
+
+body.dark-mode .form-group label {
+  color: var(--text-color);
 }
 
 .theme-toggle {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -206,7 +206,7 @@ function App() {
           </button>
         </header>
         <main className="App-main">
-          <div className="controls-card">
+          <div className={`controls-card ${openSection === 'config' ? 'open' : 'closed'}`}>
             <h2 onClick={() => toggleSection('config')}><span className="step-number">1</span> Configuration</h2>
             {openSection === 'config' && (
               <>
@@ -222,7 +222,7 @@ function App() {
                   {superMode && (
                     <>
                       <div className="form-group"><label htmlFor="total-batches">Total Batches (Max: {Math.min(maxBatchesAllowed, superMode ? 100 : 10)})</label><input id="total-batches" type="number" value={totalBatches} onChange={handleBatchChange} min="1" max={Math.min(maxBatchesAllowed, superMode ? 100 : 10)} disabled={isLoading || !selectedFile} /></div>
-                      <div className="form-group"><label htmlFor="seconds-per-batch">Seconds per Batch (Super Mode)</label><input id="seconds-per-batch" type="number" value={secondsPerBatch} onChange={handleSecondsChange} min="10" max="600" step="10" disabled={isLoading} /></div>
+                      <div className="form-group"><label htmlFor="seconds-per-batch">Batch Duration (seconds)</label><input id="seconds-per-batch" type="number" value={secondsPerBatch} onChange={handleSecondsChange} min="10" max="600" step="10" disabled={isLoading} /></div>
                       <div className="form-group"><label htmlFor="frame-interval">Frame Interval (sec)</label><input id="frame-interval" type="number" value={frameInterval} onChange={(e) => setFrameInterval(e.target.value)} min="1" disabled={isLoading} /></div>
                     </>
                   )}
@@ -233,7 +233,7 @@ function App() {
             )}
           </div>
 
-          <div className="controls-card">
+          <div className={`controls-card ${openSection === 'upload' ? 'open' : 'closed'}`}>
             <h2 onClick={() => toggleSection('upload')}><span className="step-number">2</span> Upload Video</h2>
             {openSection === 'upload' && (
               <>
@@ -257,7 +257,7 @@ function App() {
                   <div className="tooltip">
                     <p>Model: {selectedModel}</p>
                     <p>Batches: {totalBatches}</p>
-                    <p>Seconds/Batch: {secondsPerBatch}</p>
+                    <p>Batch Duration: {secondsPerBatch} seconds</p>
                     <p>Frame Interval: {frameInterval}</p>
                     <p>Type: {analysisType}</p>
                     <p>Language: {outputLanguage}</p>
@@ -269,7 +269,7 @@ function App() {
           </div>
 
           {(isLoading || analysisStatus.result || analysisStatus.error) && (
-            <div className="status-card">
+            <div className={`status-card ${openSection === 'analysis' ? 'open' : 'closed'}`}>
               <h2 onClick={() => toggleSection('analysis')}><span className="step-number">3</span> Analysis</h2>
               {openSection === 'analysis' && (
                 <>

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -37,5 +37,5 @@ export const DEFAULT_MODEL = "speedy";
 export const config = {
   MODEL_NAME: "gemini-2.5-flash",
   SOCKET: "https://videoii-server.onrender.com",
-  VERSION: "2.4.0",
+  VERSION: "2.5.0",
 };

--- a/server/package.json
+++ b/server/package.json
@@ -1,11 +1,11 @@
 {
   "name": "server",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "",
   "main": "index.js",
 "scripts": {
-  "start": "node index.js",
-  "dev": "nodemon index.js"
+  "start": "node --max-old-space-size=256 index.js",
+  "dev": "nodemon --exec node --max-old-space-size=256 index.js"
 },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- style accordion cards with open/closed states
- display batch duration in seconds
- bump app version to 2.5.0
- restrict server memory usage via Node options

## Testing
- `npm test -- --watchAll=false --passWithNoTests` within `client`
- `npm start` within `server` *(fails: GOOGLE_API_KEY not found in .env)*

------
https://chatgpt.com/codex/tasks/task_e_687968a32da483279f5473492cbebe23