### PR TITLE
UI tweaks and version bump

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -3,17 +3,18 @@
 body { font-family: 'Inter', sans-serif; background-color: var(--background-color); color: var(--text-color); margin: 0; }
 .App { display: flex; justify-content: center; padding: 40px 20px; }
 .container { width: 100%; max-width: 800px; }
-.App-header { text-align: center; margin-bottom: 40px; }
-.App-header h1 { font-size: 3rem; font-weight: 700; margin: 0; color: var(--primary-color); user-select: none; }
-.App-header p { font-size: 1.1rem; color: var(--subtle-text-color); }
+.App-header { text-align: center; margin-bottom: 30px; }
+.App-header h1 { font-size: 2.5rem; font-weight: 700; margin: 0; color: var(--primary-color); user-select: none; }
+.App-header p { font-size: 1rem; color: var(--subtle-text-color); margin-top: 4px; }
 .controls-card, .status-card { background: var(--card-background); border-radius: 12px; padding: 30px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); margin-bottom: 30px; animation: fadeIn 0.5s ease; transition: max-height 0.4s ease, padding 0.3s ease; overflow: hidden; }
-.controls-card.closed, .status-card.closed { max-height: 60px; padding: 15px 30px; opacity: 0.8; }
+.controls-card.closed, .status-card.closed { max-height: 50px; padding: 15px 30px; opacity: 0.8; }
 .controls-card.open, .status-card.open { max-height: 2000px; border: 2px solid var(--primary-color); background-color: rgba(0,122,255,0.05); }
 h2 { font-size: 1.5rem; border-bottom: 1px solid var(--border-color); padding-bottom: 15px; margin-top: 0; margin-bottom: 25px; display: flex; align-items: center; cursor: pointer; }
 .step-number { background-color: var(--primary-color); color: white; border-radius: 50%; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center; font-size: 1rem; font-weight: 700; margin-right: 15px; flex-shrink: 0; }
+.accordion-icon { margin-left: auto; font-size: 1rem; }
 .form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 20px; margin-bottom: 30px; align-items: end; }
 .form-group label { display: block; font-weight: 500; margin-bottom: 8px; font-size: 0.9rem; min-height: 1.2em; line-height: 1.2em; }
-.form-group input, .form-group select { width: 100%; padding: 12px; border-radius: 8px; border: 1px solid var(--border-color); background-color: var(--secondary-color); font-size: 1rem; box-sizing: border-box; }
+.form-group input, .form-group select { width: 100%; padding: 12px; border-radius: 8px; border: 1px solid var(--border-color); background-color: var(--secondary-color); font-size: 1rem; box-sizing: border-box; color: var(--text-color); }
 input[type="file"] { display: none; }
 .upload-button { display: inline-block; padding: 12px 20px; border: 2px dashed var(--border-color); border-radius: 8px; cursor: pointer; width: 100%; text-align: center; color: var(--subtle-text-color); transition: all 0.2s ease-in-out; box-sizing: border-box; }
 .upload-button.file-selected { border-color: var(--success-color); color: var(--success-color); font-weight: 500; }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -200,14 +200,14 @@ function App() {
       <div className="container">
         <header className="App-header">
           <h1 onClick={handleLogoClick}>VIDEOIII</h1>
-          <p>Smart Video Analysis Platform VIDEOIII</p>
+          <p>Smart Video Analysis Platform</p>
           <button className="theme-toggle" onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
             {theme === 'dark' ? '☀️' : '🌙'}
           </button>
         </header>
         <main className="App-main">
           <div className={`controls-card ${openSection === 'config' ? 'open' : 'closed'}`}>
-            <h2 onClick={() => toggleSection('config')}><span className="step-number">1</span> Configuration</h2>
+            <h2 onClick={() => toggleSection('config')}><span className="step-number">1</span> Configuration<span className="accordion-icon">{openSection === 'config' ? '▲' : '▼'}</span></h2>
             {openSection === 'config' && (
               <>
                 <div className="form-grid">
@@ -234,7 +234,7 @@ function App() {
           </div>
 
           <div className={`controls-card ${openSection === 'upload' ? 'open' : 'closed'}`}>
-            <h2 onClick={() => toggleSection('upload')}><span className="step-number">2</span> Upload Video</h2>
+            <h2 onClick={() => toggleSection('upload')}><span className="step-number">2</span> Upload Video<span className="accordion-icon">{openSection === 'upload' ? '▲' : '▼'}</span></h2>
             {openSection === 'upload' && (
               <>
                 <input id="file-upload" type="file" accept="video/*" onChange={handleFileChange} disabled={isLoading} ref={fileInputRef} />
@@ -270,7 +270,7 @@ function App() {
 
           {(isLoading || analysisStatus.result || analysisStatus.error) && (
             <div className={`status-card ${openSection === 'analysis' ? 'open' : 'closed'}`}>
-              <h2 onClick={() => toggleSection('analysis')}><span className="step-number">3</span> Analysis</h2>
+              <h2 onClick={() => toggleSection('analysis')}><span className="step-number">3</span> Analysis<span className="accordion-icon">{openSection === 'analysis' ? '▲' : '▼'}</span></h2>
               {openSection === 'analysis' && (
                 <>
                   <div className="progress-bar-container"><div className="progress-bar" style={{ width: `${analysisStatus.percent}%` }}></div></div>

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -37,5 +37,5 @@ export const DEFAULT_MODEL = "speedy";
 export const config = {
   MODEL_NAME: "gemini-2.5-flash",
   SOCKET: "https://videoii-server.onrender.com",
-  VERSION: "2.5.0",
+  VERSION: "2.5.1",
 };


### PR DESCRIPTION
## Summary
- shrink header text size, remove duplicate subtitle wording
- reduce collapsed accordion size and add arrow icons
- ensure dark mode inputs use white text
- bump client version to 2.5.1

## Testing
- `npm test --silent --no-watch`

------
https://chatgpt.com/codex/tasks/task_e_6879ccb76bf8832798d23f13a72382fb