### PR TITLE
Add dynamic version to client

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -36,10 +36,18 @@ function App() {
   const [openSection, setOpenSection] = useState('config');
   const [showFileInfo, setShowFileInfo] = useState(false);
   const [showConfigInfo, setShowConfigInfo] = useState(false);
+  const [version, setVersion] = useState(defaultConfig.VERSION);
 
   useEffect(() => {
     document.body.className = theme === 'dark' ? 'dark-mode' : '';
   }, [theme]);
+
+  useEffect(() => {
+    fetch(`${defaultConfig.SOCKET}/`)
+      .then(res => res.json())
+      .then(data => { if (data.version) setVersion(data.version); })
+      .catch(() => { /* ignore errors and keep default version */ });
+  }, []);
 
   useEffect(() => {
     socket.on('connect', () => { setSocketId(socket.id); });
@@ -324,7 +332,7 @@ function App() {
           )}
         </main>
         <footer className="App-footer">
-          <p>Developed by Mustafa Evleksiz - Version {defaultConfig.VERSION}</p>
+          <p>Developed by Mustafa Evleksiz - Version {version}</p>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- fetch version info from server on client startup
- display retrieved version in footer

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6879fa65d8b08327958eb802ad173222