### PR TITLE
Handle separate client and server versioning

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -45,7 +45,15 @@ function App() {
   useEffect(() => {
     fetch(`${defaultConfig.SOCKET}/`)
       .then(res => res.json())
-      .then(data => { if (data.version) setVersion(data.version); })
+      .then(data => {
+        if (data.client && data.client.version) {
+          setVersion(data.client.version);
+        } else if (data.clientVersion) {
+          setVersion(data.clientVersion);
+        } else if (data.version) {
+          setVersion(data.version);
+        }
+      })
       .catch(() => { /* ignore errors and keep default version */ });
   }, []);
 

--- a/server/version-info.js
+++ b/server/version-info.js
@@ -1,17 +1,28 @@
 const { execSync } = require('child_process');
 
+function formatDate(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+}
+
+function formatVersion(date) {
+  return `${date.getFullYear() % 10}.${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}.${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}`;
+}
+
+function getInfoForPath(path) {
+  const gitDateStr = execSync(`git log -1 --format=%cd --date=iso-strict -- ${path}`, { encoding: 'utf8' }).trim();
+  const date = new Date(gitDateStr);
+  return { lastModifyDate: formatDate(date), version: formatVersion(date) };
+}
+
 function getVersionInfo() {
   try {
-    const gitDateStr = execSync('git log -1 --format=%cd --date=iso-strict', { encoding: 'utf8' }).trim();
-    const date = new Date(gitDateStr);
-
-    const lastModifyDate = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
-    const version = `${date.getFullYear() % 10}.${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}.${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}`;
-
-    return { lastModifyDate, version };
+    return {
+      client: getInfoForPath('client'),
+      server: getInfoForPath('server'),
+    };
   } catch (err) {
     console.error('Could not derive version from git:', err);
-    return { lastModifyDate: null, version: null };
+    return { client: { lastModifyDate: null, version: null }, server: { lastModifyDate: null, version: null } };
   }
 }
 


### PR DESCRIPTION
## Summary
- compute Git-based version info separately for client and server
- return both versions from the API and handle them in the React app

## Testing
- `node -e "const {getVersionInfo}=require('./server/version-info'); console.log(getVersionInfo());"`

------
https://chatgpt.com/codex/tasks/task_e_687a0b9f5d348327b280ef904889271b