### PR TITLE
Fix version info retrieval

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -29,7 +29,12 @@ app.use(cors());
 
 app.get('/', (req, res) => {
   const info = getVersionInfo();
-  res.json(info);
+  res.json({ client: info.client });
+});
+
+// detailed version info for internal use
+app.get('/version', (req, res) => {
+  res.json(getVersionInfo());
 });
 
 // Yüklenen dosyalar için geçici bir klasör oluştur

--- a/server/version-info.js
+++ b/server/version-info.js
@@ -1,4 +1,6 @@
 const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 function formatDate(date) {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
@@ -8,17 +10,43 @@ function formatVersion(date) {
   return `${date.getFullYear() % 10}.${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}.${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}`;
 }
 
-function getInfoForPath(path) {
-  const gitDateStr = execSync(`git log -1 --format=%cd --date=iso-strict -- ${path}`, { encoding: 'utf8' }).trim();
-  const date = new Date(gitDateStr);
-  return { lastModifyDate: formatDate(date), version: formatVersion(date) };
+function tryGetGitDate(targetPath) {
+  try {
+    const gitDateStr = execSync(`git log -1 --format=%cd --date=iso-strict -- ${targetPath}`, { encoding: 'utf8' }).trim();
+    return new Date(gitDateStr);
+  } catch (_) {
+    return null;
+  }
+}
+
+function getFsDate(targetPath) {
+  try {
+    return fs.statSync(targetPath).mtime;
+  } catch (_) {
+    return null;
+  }
+}
+
+function getPackageVersion(targetPath) {
+  try {
+    const pkg = require(path.join(targetPath, 'package.json'));
+    return pkg.version || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function getInfoForPath(targetPath) {
+  const date = tryGetGitDate(targetPath) || getFsDate(targetPath);
+  const version = getPackageVersion(targetPath);
+  return { lastModifyDate: date ? formatDate(date) : null, version };
 }
 
 function getVersionInfo() {
   try {
     return {
-      client: getInfoForPath('client'),
-      server: getInfoForPath('server'),
+      client: getInfoForPath(path.join(__dirname, '..', 'client')),
+      server: getInfoForPath(__dirname),
     };
   } catch (err) {
     console.error('Could not derive version from git:', err);


### PR DESCRIPTION
## Summary
- gather client/server versions independently by reading each package.json
- expose internal version info via `/version` endpoint
- keep root endpoint to only expose client version

## Testing
- `node -e "const {getVersionInfo}=require('./server/version-info.js'); console.log(getVersionInfo());"`
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0e69ac988327b5cf5cc899cfe197