### PR TITLE
Set server memory limit to 200MB

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
 "scripts": {
-  "start": "node --max-old-space-size=256 index.js",
-  "dev": "nodemon --exec node --max-old-space-size=256 index.js"
+  "start": "node --max-old-space-size=200 index.js",
+  "dev": "nodemon --exec node --max-old-space-size=200 index.js"
 },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- lower Node.js memory cap from 256MB to 200MB

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `server`

------
https://chatgpt.com/codex/tasks/task_e_687a21b2f7c48327b9c98dbe9fd05130