### PR TITLE
Update version logic

### DIFF
--- a/client/src/config.js
+++ b/client/src/config.js
@@ -37,5 +37,6 @@ export const DEFAULT_MODEL = "speedy";
 export const config = {
   MODEL_NAME: "gemini-2.5-flash",
   SOCKET: "https://videoii-server.onrender.com",
-  VERSION: "2.5.2",
+  // Default client version derived from the last modification date
+  VERSION: process.env.REACT_APP_VERSION || "2.0718.1259",
 };

--- a/server/version-info.js
+++ b/server/version-info.js
@@ -3,11 +3,11 @@ const fs = require('fs');
 const path = require('path');
 
 function formatDate(date) {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+  return `${String(date.getDate()).padStart(2, '0')}-${String(date.getMonth() + 1).padStart(2, '0')}-${date.getFullYear()} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
 }
 
-function formatVersion(date) {
-  return `${date.getFullYear() % 10}.${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}.${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}`;
+function formatVersion(date, prefix) {
+  return `${prefix}.${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}.${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}`;
 }
 
 function tryGetGitDate(targetPath) {
@@ -36,17 +36,20 @@ function getPackageVersion(targetPath) {
   }
 }
 
-function getInfoForPath(targetPath) {
+function getInfoForPath(targetPath, prefix) {
   const date = tryGetGitDate(targetPath) || getFsDate(targetPath);
-  const version = getPackageVersion(targetPath);
-  return { lastModifyDate: date ? formatDate(date) : null, version };
+  if (!date) {
+    const fallback = getPackageVersion(targetPath);
+    return { lastModifyDate: null, version: fallback };
+  }
+  return { lastModifyDate: formatDate(date), version: formatVersion(date, prefix) };
 }
 
 function getVersionInfo() {
   try {
     return {
-      client: getInfoForPath(path.join(__dirname, '..', 'client')),
-      server: getInfoForPath(__dirname),
+      client: getInfoForPath(path.join(__dirname, '..', 'client'), '2'),
+      server: getInfoForPath(__dirname, '1'),
     };
   } catch (err) {
     console.error('Could not derive version from git:', err);


### PR DESCRIPTION
## Summary
- adjust date format in `version-info`
- derive version from last modification date
- allow overriding client version via `REACT_APP_VERSION`

## Testing
- `npm test --prefix client --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687a25ab4ad08327a11d74aa64f0c9ff