### PR TITLE
Add standalone client version info

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.5.2",
+  "version": "2.0718.1437",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -38,5 +38,5 @@ export const config = {
   MODEL_NAME: "gemini-2.5-flash",
   SOCKET: "https://videoii-server.onrender.com",
   // Default client version derived from the last modification date
-  VERSION: process.env.REACT_APP_VERSION || "2.0718.1259",
+  VERSION: process.env.REACT_APP_VERSION || "2.0718.1437",
 };

--- a/client/version-info.js
+++ b/client/version-info.js
@@ -1,0 +1,51 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function formatDate(date) {
+  return `${String(date.getDate()).padStart(2, '0')}-${String(date.getMonth() + 1).padStart(2, '0')}-${date.getFullYear()} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+}
+
+function formatVersion(date) {
+  return `2.${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}.${String(date.getHours()).padStart(2, '0')}${String(date.getMinutes()).padStart(2, '0')}`;
+}
+
+function tryGetGitDate(targetPath) {
+  try {
+    const gitDateStr = execSync(`git log -1 --format=%cd --date=iso-strict -- ${targetPath}`, { encoding: 'utf8' }).trim();
+    return new Date(gitDateStr);
+  } catch (_) {
+    return null;
+  }
+}
+
+function getFsDate(targetPath) {
+  try {
+    return fs.statSync(targetPath).mtime;
+  } catch (_) {
+    return null;
+  }
+}
+
+function getPackageVersion(targetPath) {
+  try {
+    const pkg = require(path.join(targetPath, 'package.json'));
+    return pkg.version || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function getClientInfo() {
+  const date = tryGetGitDate(__dirname) || getFsDate(__dirname);
+  if (!date) {
+    return { lastModifyDate: null, version: getPackageVersion(__dirname) };
+  }
+  return { lastModifyDate: formatDate(date), version: formatVersion(date) };
+}
+
+if (require.main === module) {
+  console.log(getClientInfo().version);
+}
+
+module.exports = { getClientInfo };

--- a/server/version-info.js
+++ b/server/version-info.js
@@ -1,6 +1,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { getClientInfo } = require('../client/version-info.js');
 
 function formatDate(date) {
   return `${String(date.getDate()).padStart(2, '0')}-${String(date.getMonth() + 1).padStart(2, '0')}-${date.getFullYear()} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
@@ -48,12 +49,15 @@ function getInfoForPath(targetPath, prefix) {
 function getVersionInfo() {
   try {
     return {
-      client: getInfoForPath(path.join(__dirname, '..', 'client'), '2'),
+      client: getClientInfo(),
       server: getInfoForPath(__dirname, '1'),
     };
   } catch (err) {
     console.error('Could not derive version from git:', err);
-    return { client: { lastModifyDate: null, version: null }, server: { lastModifyDate: null, version: null } };
+    return {
+      client: { lastModifyDate: null, version: null },
+      server: { lastModifyDate: null, version: null },
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- add `client/version-info.js` to compute client version separately
- update `server/version-info.js` to read the client info from the new file
- sync package version to `2.0718.1437`
- update client fallback version

## Testing
- `npm test --silent` (client)
- `npm test --silent` (server)


------
https://chatgpt.com/codex/tasks/task_e_687a5b1917808327b12bd99b9f7621dd