### PR TITLE
Enable dynamic server version based on modification time

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -28,8 +28,7 @@ const PORT = process.env.PORT || 5001;
 app.use(cors());
 
 app.get('/', (req, res) => {
-  const info = getVersionInfo();
-  res.json({ client: info.client });
+  res.json(getVersionInfo());
 });
 
 // detailed version info for internal use

--- a/server/package.json
+++ b/server/package.json
@@ -1,12 +1,14 @@
 {
   "name": "server",
-  "version": "2.5.1",
+  "version": "1.0718.1452",
   "description": "",
   "main": "index.js",
-"scripts": {
-  "start": "node --max-old-space-size=200 index.js",
-  "dev": "nodemon --exec node --max-old-space-size=200 index.js"
-},
+  "scripts": {
+    "prestart": "node ./version-info.js --update-package-json",
+    "start": "node --max-old-space-size=200 index.js",
+    "predev": "node ./version-info.js --update-package-json",
+    "dev": "nodemon --exec node --max-old-space-size=200 index.js"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/server/version-info.js
+++ b/server/version-info.js
@@ -46,11 +46,15 @@ function getInfoForPath(targetPath, prefix) {
   return { lastModifyDate: formatDate(date), version: formatVersion(date, prefix) };
 }
 
+function getServerInfo() {
+  return getInfoForPath(__dirname, '1');
+}
+
 function getVersionInfo() {
   try {
     return {
       client: getClientInfo(),
-      server: getInfoForPath(__dirname, '1'),
+      server: getServerInfo(),
     };
   } catch (err) {
     console.error('Could not derive version from git:', err);
@@ -61,4 +65,22 @@ function getVersionInfo() {
   }
 }
 
-module.exports = { getVersionInfo };
+function updatePackageVersion() {
+  const info = getServerInfo();
+  if (!info.version) return;
+
+  const pkgPath = path.join(__dirname, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  pkg.version = info.version;
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+}
+
+if (require.main === module) {
+  if (process.argv.includes('--update-package-json')) {
+    updatePackageVersion();
+  } else {
+    console.log(getServerInfo().version);
+  }
+}
+
+module.exports = { getVersionInfo, getServerInfo, updatePackageVersion };


### PR DESCRIPTION
## Summary
- update server package version dynamically from `version-info.js`
- add CLI in `version-info.js` to update `package.json`
- expose both client and server version info on the root route

## Testing
- `npm test --prefix server` *(fails: Missing script)*
- `node server/version-info.js`
- `node -e "console.log(require('./server/version-info.js').getVersionInfo())"`


------
https://chatgpt.com/codex/tasks/task_e_687a5e0f6fdc83279fa5405e321f0283