### PR TITLE
Hide theme toggle until super mode

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -244,14 +244,15 @@ function App() {
         <header className="App-header">
           <h1 onClick={handleLogoClick}>VIDEOIII</h1>
           <p>Smart Video Analysis Platform</p>
-          <button
-            className="theme-toggle"
-            onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-            disabled={!superMode}
-            title={!superMode ? 'Activate super mode to toggle theme' : ''}
-          >
-            {theme === 'dark' ? '☀️' : '🌙'}
-          </button>
+          {superMode && (
+            <button
+              className="theme-toggle"
+              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+              title="Toggle theme"
+            >
+              {theme === 'dark' ? '☀️' : '🌙'}
+            </button>
+          )}
         </header>
         <main className="App-main">
           <div className={`controls-card ${openSection === 'config' ? 'open' : 'closed'}`}>


### PR DESCRIPTION
## Summary
- hide the theme toggle button unless super mode is active

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687a626c9eb88327be5865aab7086cd5