### PR TITLE
Add version auto-update for client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
+    "prestart": "node ./version-info.js --update-package-json",
+    "prebuild": "node ./version-info.js --update-package-json",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/client/version-info.js
+++ b/client/version-info.js
@@ -44,8 +44,22 @@ function getClientInfo() {
   return { lastModifyDate: formatDate(date), version: formatVersion(date) };
 }
 
-if (require.main === module) {
-  console.log(getClientInfo().version);
+function updatePackageVersion() {
+  const info = getClientInfo();
+  if (!info.version) return;
+
+  const pkgPath = path.join(__dirname, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  pkg.version = info.version;
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
 }
 
-module.exports = { getClientInfo };
+if (require.main === module) {
+  if (process.argv.includes('--update-package-json')) {
+    updatePackageVersion();
+  } else {
+    console.log(getClientInfo().version);
+  }
+}
+
+module.exports = { getClientInfo, updatePackageVersion };


### PR DESCRIPTION
## Summary
- auto-update client version when starting or building
- run the version-info script with `--update-package-json`

## Testing
- `npm test` *(fails: No tests found)*
- `npm test` in server *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a64b71dac8327a13254cf9d91089c