### PR TITLE
feat: add detailed progress logging

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -37,6 +37,8 @@ input[type="file"] { display: none; }
 .time-remaining { color: var(--subtle-text-color); font-size: 0.9rem; margin-top: 8px; }
 .result-container { background: #2d2d2d; color: #e0e0e0; border-radius: 8px; padding: 20px; margin-top: 20px; text-align: left; max-height: 500px; overflow-y: auto; font-size: 0.9rem; }
 .report-content { white-space: pre-wrap; word-wrap: break-word; font-family: 'Courier New', Courier, monospace; }
+.log-container { max-height: 150px; overflow-y: auto; background-color: var(--secondary-color); border: 1px solid var(--border-color); border-radius: 4px; padding: 10px; font-size: 0.85rem; text-align: left; margin-top: 10px; }
+.log-entry { margin-bottom: 4px; }
 .reset-button { width: 100%; padding: 15px; font-size: 1.1rem; font-weight: 700; color: white; background-color: var(--success-color); border: none; border-radius: 8px; cursor: pointer; transition: background-color 0.2s; margin-top: 30px; }
 .reset-button:hover { opacity: 0.85; }
 .video-preview-container { margin-top: 20px; border: 1px solid var(--border-color); border-radius: 8px; overflow: hidden; }


### PR DESCRIPTION
## Summary
- add upload and processing progress tracking with detailed log storage
- show separate progress bars and log panel in analysis view
- instrument device processing to report frame capture progress

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (client)


------
https://chatgpt.com/codex/tasks/task_e_688faebd31c483279e7cbfb463dbd095