### PR TITLE
Handle lack of stream capture support with server fallback

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -37,7 +37,7 @@ input[type="file"] { display: none; }
 .time-remaining { color: var(--subtle-text-color); font-size: 0.9rem; margin-top: 8px; }
 .result-container { background: #2d2d2d; color: #e0e0e0; border-radius: 8px; padding: 20px; margin-top: 20px; text-align: left; max-height: 500px; overflow-y: auto; font-size: 0.9rem; }
 .report-content { white-space: pre-wrap; word-wrap: break-word; font-family: 'Courier New', Courier, monospace; }
-.log-container { max-height: 150px; overflow-y: auto; background-color: var(--secondary-color); border: 1px solid var(--border-color); border-radius: 4px; padding: 10px; font-size: 0.85rem; text-align: left; margin-top: 10px; }
+.log-container { height: 150px; overflow-y: auto; background-color: var(--secondary-color); border: 1px solid var(--border-color); border-radius: 4px; padding: 10px; font-size: 0.85rem; text-align: left; margin-top: 10px; }
 .log-entry { margin-bottom: 4px; }
 .reset-button { width: 100%; padding: 15px; font-size: 1.1rem; font-weight: 700; color: white; background-color: var(--success-color); border: none; border-radius: 8px; cursor: pointer; transition: background-color 0.2s; margin-top: 30px; }
 .reset-button:hover { opacity: 0.85; }


### PR DESCRIPTION
## Summary
- Fallback to server processing when the browser lacks stream capture support and log a clear message
- Add reusable helper to upload videos directly to the server
- Fix log panel styling to keep its own scroll area

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688fc66a89c083279185659d482e3586