### PR TITLE
Add OpenAI option and gate logs to super mode

### DIFF
--- a/client/src/config.js
+++ b/client/src/config.js
@@ -6,33 +6,40 @@ export const MODELS = {
   speedy: {
     label: "\uD83D\uDE80 Speedy",
     note: "En hızlı model",
-    secondsPerBatch: 60,
+    secondsPerBatch: 120,
     meetingFrame: 12,
     videoFrame: 4,
-    maxDuration: 1800,
+    maxDuration: 7200,
     maxSize: 200,
   },
   regular: {
     label: "\uD83E\uDD85 Regular",
     note: "Akıllı ve hızlı model",
-    secondsPerBatch: 30,
+    secondsPerBatch: 60,
     meetingFrame: 6,
     videoFrame: 2,
-    maxDuration: 900,
+    maxDuration: 3600,
     maxSize: 150,
   },
   smart: {
     label: "\uD83E\uDD81 Smart",
     note: "En akıllı model",
-    secondsPerBatch: 20,
+    secondsPerBatch: 30,
     meetingFrame: 2,
     videoFrame: 0.5,
-    maxDuration: 300,
+    maxDuration: 1800,
     maxSize: 120,
   },
 };
 
 export const DEFAULT_MODEL = "speedy";
+
+export const AI_MODULES = {
+  gemini: { label: "Gemini" },
+  openai: { label: "OpenAI" },
+};
+
+export const DEFAULT_AI_MODULE = 'gemini';
 
 export const config = {
   MODEL_NAME: "gemini-2.5-flash",

--- a/server/config.js
+++ b/server/config.js
@@ -11,11 +11,11 @@ const config = {
   FRAMES_FOLDER: 'temp_frames',
   AUDIO_FOLDER: 'temp_audio',
   // Upload limit for incoming files (in megabytes)
-  MAX_UPLOAD_SIZE_MB: 250,
+  MAX_UPLOAD_SIZE_MB: 500,
 
   // --- Batch (Parça) Analiz Ayarları ---
   TOTAL_BATCHES: 1,
-  SECONDS_PER_BATCH: 60,
+  SECONDS_PER_BATCH: 120,
   FRAME_INTERVAL_SECONDS: 10,
 
   // --- Görsel Çıktı Ayarları ---

--- a/server/index.js
+++ b/server/index.js
@@ -77,6 +77,7 @@ app.post('/api/analyze', (req, res, next) => {
     analysisType: req.body.analysisType,
     outputLanguage: req.body.outputLanguage,
     socketId: req.body.socketId,
+    aiModule: req.body.aiModule || 'gemini',
     totalBatches: parseInt(req.body.totalBatches, 10) || 1,
     secondsPerBatch: parseInt(req.body.secondsPerBatch, 10) || 60,
     frameInterval: parseInt(req.body.frameInterval, 10) || 10,
@@ -127,6 +128,7 @@ app.post('/api/analyze-browser', (req, res, next) => {
     analysisType: req.body.analysisType,
     outputLanguage: req.body.outputLanguage,
     socketId: req.body.socketId,
+    aiModule: req.body.aiModule || 'gemini',
   };
   if (!settings.socketId) return res.status(400).json({ error: 'Socket ID not found.' });
   res.status(202).json({ message: 'Analysis request accepted.' });

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "express": "^5.1.0",
     "fluent-ffmpeg": "^2.1.3",
     "multer": "^2.0.1",
+    "openai": "^4.0.0",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- allow choosing AI module in super mode (Gemini or OpenAI)
- add OpenAI-based transcription and meeting-minutes generation backend
- only record verbose processing logs while super mode is active and extend defaults for longer videos

## Testing
- `npm test --prefix server` *(fails: Missing script: "test")*
- `CI=true npm test --prefix client -- --watchAll=false` *(fails: No tests found, exiting with code 1)*


------
https://chatgpt.com/codex/tasks/task_e_688fd4d125f4832787630091a601a19f