### PR TITLE
Add super mode toggle, allow model selection in normal mode

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
 :root { --primary-color: #007aff; --secondary-color: #f2f2f7; --background-color: #f9f9fb; --card-background: #ffffff; --text-color: #1d1d1f; --subtle-text-color: #6e6e73; --border-color: #d1d1d6; --success-color: #34c759; --error-color: #ff3b30; }
-body { font-family: 'Inter', sans-serif; background-color: var(--background-color); color: var(--text-color); margin: 0; }
+body { font-family: 'Inter', sans-serif; background-color: var(--background-color); color: var(--text-color); margin: 0; font-size: 0.95rem; }
 .App { display: flex; justify-content: center; padding: 40px 20px; }
 .container { width: 100%; max-width: 800px; }
 .App-header { text-align: center; margin-bottom: 30px; }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -248,8 +248,17 @@ function App() {
 
   const handleLogoClick = () => {
     const newClickCount = logoClicks + 1;
-    setLogoClicks(newClickCount);
-    if (newClickCount >= 5 && !superMode) { console.log("Super Mode Activated!"); setSuperMode(true); }
+    if (!superMode && newClickCount >= 5) {
+      console.log("Super Mode Activated!");
+      setSuperMode(true);
+      setLogoClicks(0);
+    } else if (superMode && newClickCount >= 5) {
+      console.log("Super Mode Deactivated!");
+      setSuperMode(false);
+      setLogoClicks(0);
+    } else {
+      setLogoClicks(newClickCount);
+    }
   };
 
   const handleBatchChange = (e) => {
@@ -364,14 +373,12 @@ function App() {
                     </select>
                   </div>
                 )}
-                {superMode && (
-                  <div className="form-group model-group">
-                    <label htmlFor="model-select">Model</label>
-                    <select id="model-select" value={selectedModel} onChange={(e) => setSelectedModel(e.target.value)} disabled={isLoading}>
-                      {Object.entries(MODELS).map(([k, m]) => <option key={k} value={k}>{`${m.label} - ${m.note}`}</option>)}
-                    </select>
-                  </div>
-                )}
+                <div className="form-group model-group">
+                  <label htmlFor="model-select">Model</label>
+                  <select id="model-select" value={selectedModel} onChange={(e) => setSelectedModel(e.target.value)} disabled={isLoading}>
+                    {Object.entries(MODELS).map(([k, m]) => <option key={k} value={k}>{`${m.label} - ${m.note}`}</option>)}
+                  </select>
+                </div>
                 {superMode && (
                   <div className="form-group">
                     <label htmlFor="processing-mode">Processing</label>


### PR DESCRIPTION
## Summary
- allow toggling Super Mode on/off by clicking the logo five times
- show model dropdown even when Super Mode is inactive
- slightly reduce base font size for a more compact UI

## Testing
- `npm test -- --watchAll=false` (fails: No tests found)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68911cb0b11c8327baef7feb8ba8ee75